### PR TITLE
Raw solution for issue #338 (ability to change node identifier width)

### DIFF
--- a/sources/all.pro
+++ b/sources/all.pro
@@ -8,10 +8,8 @@ CONFIG += ordered
 DESTDIR = ./bin
 
 SUBDIRS = plugins/scg \
-          kbe
-
           #plugins/scn \
-          #plugins/scs \
-
+          plugins/scs \
+          kbe
 
 #win32: SUBDIRS += updater

--- a/sources/all.pro
+++ b/sources/all.pro
@@ -8,8 +8,10 @@ CONFIG += ordered
 DESTDIR = ./bin
 
 SUBDIRS = plugins/scg \
-          #plugins/scn \
-          plugins/scs \
           kbe
+
+          #plugins/scn \
+          #plugins/scs \
+
 
 #win32: SUBDIRS += updater

--- a/sources/plugins/scg/commands/scgcommandidtfwidthchange.cpp
+++ b/sources/plugins/scg/commands/scgcommandidtfwidthchange.cpp
@@ -1,0 +1,34 @@
+#include "scgcommandidtfwidthchange.h"
+
+#include <scgtextitem.h>
+
+SCgCommandIdtfWidthChange::SCgCommandIdtfWidthChange(SCgObject *obj,
+                                                     SCgScene *scene,
+                                                     int oldIdtfWidth,
+                                                     int newIdtfWidth,
+                                                     QUndoCommand *parent)
+    : SCgBaseCommand(scene, obj, parent),
+      mObject(obj)
+{
+    Q_ASSERT(obj);
+
+    setText(QObject::tr("Change identifier width"));
+}
+
+SCgCommandIdtfWidthChange::~SCgCommandIdtfMove()
+{
+}
+
+void SCgCommandIdtfWidthChange::redo()
+{
+    if (mObject)
+        mObject->mtxtItem->setTextWidth(mNewIdtfWidth);
+    SCgBaseCommand::redo();
+}
+
+void SCgCommandIdtfWidthChange::undo()
+{
+    if (mObject)
+        mObject->mTextItem->setTextWidth(mOldIdtfWidth);
+    SCgBaseCommand::undo();
+}

--- a/sources/plugins/scg/commands/scgcommandidtfwidthchange.h
+++ b/sources/plugins/scg/commands/scgcommandidtfwidthchange.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include "scgbasecommand.h"
+
+
+class SCgCommandIdtfWidthChange : public SCgBaseCommand
+{
+public:
+    /**
+    * @brief Constructor
+    * @param idtf           Item that contains object's identifier
+    * @param scene          Pointer to the graphics scene that contains current object
+    * @param oldWidth       Width of the identifier before changing
+    * @param newPosition    Width of the identifier after changing
+    * @param parent         Pointer to parent's undo command
+    */
+    explicit SCgCommandIdtfWidthChange(SCgObject *obj,
+                                       SCgScene *scene,
+                                       int oldIdtfWidth,
+                                       int newIdtfWidth,
+                                       QUndoCommand *parent = 0);
+
+    //! Destructor
+    virtual ~SCgCommandIdtfWidthChange();
+protected:
+    //! @copydoc QUndoCommand::redo
+    void redo();
+    //! @copydoc QUndoCommand::undo
+    void undo();
+
+private:
+    //! Item that store object's identifier
+    SCgObject *mObject;
+    //! Identifier width before changing
+    int mOldIdtfWidth;
+    //! Identifier width after changing
+    int mNewIdtfWidth;
+};

--- a/sources/plugins/scg/scg.pro
+++ b/sources/plugins/scg/scg.pro
@@ -94,7 +94,8 @@ HEADERS += \
     commands/scgcommandswappairorient.h \
     commands/scgcommandremovebreakpoints.h \
     commands/scgcommandminimizecontour.h \
-    scgnodetextitem.h
+    scgnodetextitem.h \
+    commands/scgcommandidtfwidthchange.h
 
 SOURCES += \
     scgwindow.cpp \
@@ -172,7 +173,8 @@ SOURCES += \
     commands/scgcommandswappairorient.cpp \
     commands/scgcommandremovebreakpoints.cpp \
     commands/scgcommandminimizecontour.cpp \
-    scgnodetextitem.cpp
+    scgnodetextitem.cpp \
+    commands/scgcommandidtfwidthchange.cpp
 
 TRANSLATIONS += media/translations/scg_en_EN.ts \
                 media/translations/scg_ru_RU.ts

--- a/sources/plugins/scg/scgnodetextitem.cpp
+++ b/sources/plugins/scg/scgnodetextitem.cpp
@@ -5,7 +5,6 @@
  */
 
 #include <QGraphicsSceneMouseEvent>
-#include <QGraphicsTextItem>
 #include <QCursor>
 #include "scgnodetextitem.h"
 
@@ -178,7 +177,7 @@ void SCgNodeTextItem::changeIdtfWidth(double dx)
 
     QRectF newRect = boundingRect();
     QPointF newPos;
-    QPointF diff;
+    QPointF diff = QPointF();
 
     switch(idtfPos)
     {
@@ -195,7 +194,7 @@ void SCgNodeTextItem::changeIdtfWidth(double dx)
             diff = prevRect.topRight() - newRect.topRight();
             break;
         default:
-            throw std::exception("Unknown enum member.");
+            qWarning("Unknown enum member.");
     }
 
     newPos = prevPos + diff;

--- a/sources/plugins/scg/scgnodetextitem.cpp
+++ b/sources/plugins/scg/scgnodetextitem.cpp
@@ -6,7 +6,11 @@
 
 #include <QGraphicsSceneMouseEvent>
 #include "scgnodetextitem.h"
+#include <QCursor>
+#include <cmath>
 
+// Used as width of horizontal borders of identifier bounding rectangle
+const int adjust = 10;
 
 SCgNodeTextItem::SCgNodeTextItem(const QString &str, SCgNode* parent, SCgNode::IdentifierPosition idtfPos)
     : SCgTextItem(str,(QGraphicsItem*)parent)
@@ -15,6 +19,7 @@ SCgNodeTextItem::SCgNodeTextItem(const QString &str, SCgNode* parent, SCgNode::I
     Q_CHECK_PTR(parent);
     mParentItem = parent;
     updateTextPos(mTextPos);
+    setAcceptHoverEvents(true);
 }
 
 
@@ -25,6 +30,7 @@ SCgNodeTextItem::SCgNodeTextItem(SCgNode *parent, SCgNode::IdentifierPosition id
     Q_CHECK_PTR(parent);
     mParentItem = parent;
     updateTextPos(mTextPos);
+    setAcceptHoverEvents(true);
 }
 
 
@@ -32,11 +38,55 @@ SCgNodeTextItem::~SCgNodeTextItem()
 {
 
 }
+
+void SCgNodeTextItem::hoverEnterEvent(QGraphicsSceneHoverEvent *event)
+{
+    setCursor(Qt::OpenHandCursor);
+}
+
+void SCgNodeTextItem::hoverMoveEvent(QGraphicsSceneHoverEvent *event)
+{
+    if ( (nodeTextPos() == SCgNode::TopLeft || nodeTextPos() == SCgNode::BottomLeft) &&
+            (event->pos().x() < boundingRect().left() + adjust) )
+    {
+        setCursor(Qt::SizeHorCursor);
+    }
+    else if ( (nodeTextPos() == SCgNode::TopRight || nodeTextPos() == SCgNode::BottomRight) &&
+             (event->pos().x() > boundingRect().right() - adjust) )
+    {
+        setCursor(Qt::SizeHorCursor);
+    }
+    else setCursor(Qt::OpenHandCursor);
+}
+
+void SCgNodeTextItem::mouseReleaseEvent(QGraphicsSceneMouseEvent *event)
+{
+    if (event->button() == Qt::LeftButton)
+        setCursor(Qt::OpenHandCursor);
+}
+
 void SCgNodeTextItem::mouseMoveEvent(QGraphicsSceneMouseEvent *event)
 {
+    if (event->buttons() & Qt::LeftButton)
+        setCursor(Qt::ClosedHandCursor);
 
-    if ((flags() & QGraphicsItem::ItemIsMovable) != 0)
-        setNodeTextPos(posToIdtfPos(mapToParent(event->pos())));
+    double dx = event->pos().x() - event->lastPos().x();
+    if ( (nodeTextPos() == SCgNode::TopLeft || nodeTextPos() == SCgNode::BottomLeft) &&
+            (event->pos().x() < boundingRect().left() + adjust) )
+    {
+        setCursor(Qt::SizeHorCursor);
+        changeIdtfWidth(-dx);
+    }
+    else if ( (nodeTextPos() == SCgNode::TopRight || nodeTextPos() == SCgNode::BottomRight) &&
+             (event->pos().x() > boundingRect().right() - adjust) )
+    {
+        setCursor(Qt::SizeHorCursor);
+        changeIdtfWidth(dx);
+    }
+    {
+        if ((flags() & QGraphicsItem::ItemIsMovable) != 0)
+            setNodeTextPos(posToIdtfPos(mapToParent(event->pos())));
+    }
 }
 
 
@@ -116,4 +166,39 @@ void SCgNodeTextItem::setPlainText(const QString &text)
 {
     SCgTextItem::setPlainText(text);
     updateTextPos(mTextPos);
+}
+
+void SCgNodeTextItem::changeIdtfWidth(double dx)
+{
+    QRectF prevRect = boundingRect();
+    QPointF prevPos = pos();
+
+    SCgNode::IdentifierPosition idtfPos = nodeTextPos();
+
+    this->setTextWidth(this->textWidth() + dx);
+
+    QRectF newRect = boundingRect();
+    QPointF newPos;
+    QPointF diff;
+
+    switch(idtfPos)
+    {
+        case SCgNode::TopLeft :
+            diff = prevRect.bottomRight() - newRect.bottomRight();
+            break;
+        case SCgNode::TopRight :
+            diff = prevRect.bottomLeft() - newRect.bottomLeft();
+            break;
+        case SCgNode::BottomRight :
+            diff = prevRect.topLeft() - newRect.topLeft();
+            break;
+        case SCgNode::BottomLeft :
+            diff = prevRect.topRight() - newRect.topRight();
+            break;
+        default:
+            throw std::exception("Unknown enum member.");
+    }
+
+    newPos = prevPos + diff;
+    setPos(newPos);
 }

--- a/sources/plugins/scg/scgnodetextitem.cpp
+++ b/sources/plugins/scg/scgnodetextitem.cpp
@@ -5,9 +5,9 @@
  */
 
 #include <QGraphicsSceneMouseEvent>
-#include "scgnodetextitem.h"
+#include <QGraphicsTextItem>
 #include <QCursor>
-#include <cmath>
+#include "scgnodetextitem.h"
 
 // Used as width of horizontal borders of identifier bounding rectangle
 const int adjust = 10;
@@ -174,7 +174,6 @@ void SCgNodeTextItem::changeIdtfWidth(double dx)
     QPointF prevPos = pos();
 
     SCgNode::IdentifierPosition idtfPos = nodeTextPos();
-
     this->setTextWidth(this->textWidth() + dx);
 
     QRectF newRect = boundingRect();

--- a/sources/plugins/scg/scgnodetextitem.h
+++ b/sources/plugins/scg/scgnodetextitem.h
@@ -32,13 +32,18 @@ public:
     void setPlainText(const QString &text);
 
 protected:
+    virtual void hoverEnterEvent(QGraphicsSceneHoverEvent *event);
+    virtual void hoverMoveEvent(QGraphicsSceneHoverEvent *event);
     virtual void mouseMoveEvent(QGraphicsSceneMouseEvent *event);
+    virtual void mouseReleaseEvent(QGraphicsSceneMouseEvent *event);
 
     void setNodeTextPos(SCgNode::IdentifierPosition pos);
     SCgNode::IdentifierPosition nodeTextPos() const;
 
     void updateTextPos(SCgNode::IdentifierPosition pos);
     SCgNode::IdentifierPosition posToIdtfPos(const QPointF &point) const;
+
+    void changeIdtfWidth(double dx);
 
     SCgNode::IdentifierPosition mTextPos;
     SCgNode *mParentItem;

--- a/sources/plugins/scg/scgscene.cpp
+++ b/sources/plugins/scg/scgscene.cpp
@@ -45,6 +45,8 @@
 #include "commands/scgcommandswappairorient.h"
 #include "commands/scgcommandremovebreakpoints.h"
 #include "commands/scgcommandminimizecontour.h"
+//TODO: Implement call of SCgCommandIdtfWidthChange for SCgNodeTextItem (changing identifier's width - method: changeIdtfWidth(...)).
+#include "commands/scgcommandidtfwidthchange.h"
 
 #include <QUrl>
 #include <QFile>


### PR DESCRIPTION
[issue #338]
- [x] изменение ширины текстового идентификатора узла с автоматическим переносом текста, если он не помещается
- [x] фиксация угла "стыковки" идентификатора с узлом при изменении размеров идентификатора
- [x] класс для соответствующей команды
- [ ] выравнивание (left/right alignment) текста в идентификаторе в зависимости от положения идентификатора (по горизонтальной оси - слева/справа от узла)
- [ ] вызов соответствующей команды при изменении размера идентификатора (и, соответственно, возможность использования undo/redo и отображение изменений в истории)
- [ ] сохранение размера после закрытия сохранённого файла
- [ ] ограничение на изменение ширины идентификатора больше, чем необходимо, чтобы уместить текст

P.S.: Текущее взаимодействие с идентификатором при изменении его ширины может иногда быть не идеальным (курсор может оказаться на расстоянии от "растягиваемой" стороны). На данный момент пока не разобрался, с чем это связано.
