### PR TITLE
#387, fix exit, about, find, undo, redo hot key

### DIFF
--- a/sources/kbe/mainwindow.cpp
+++ b/sources/kbe/mainwindow.cpp
@@ -173,6 +173,9 @@ void MainWindow::createActions()
     connect(ui->actionAbout_Qt, SIGNAL(triggered()), this, SLOT(onHelpAboutQt()));
     connect(ui->actionFeedback, SIGNAL(triggered()), this, SLOT(onFeedback()));
     connect(ui->actionGuide, SIGNAL(triggered()), this, SLOT(onGuide()));
+
+    this->addAction(ui->actionExit);
+    this->addAction(ui->actionAbout);
 }
 
 void MainWindow::updateEvent(EditorInterface *editor, EditEvents event)

--- a/sources/plugins/scg/scgwindow.cpp
+++ b/sources/plugins/scg/scgwindow.cpp
@@ -124,16 +124,19 @@ void SCgWindow::createActions()
     mActionFind = new QAction(findIcon("edit-find.png"), tr("&Find by Identifier..."), this);
     mActionFind->setShortcuts(QKeySequence::Find);
     mActionFind->setIcon(QIcon::fromTheme("edit-find", findIcon("edit-find.png")));
+    this->addAction(mActionFind);
     connect(mActionFind, SIGNAL(triggered()), this, SLOT(showTextSearch()));
 
     mActionUndo = mUndoStack->createUndoAction(this, tr("Undo"));//new QAction(tr("Undo"),this);
     mActionUndo->setEnabled(false);
     mActionUndo->setShortcut(QKeySequence::Undo);
+    this->addAction(mActionUndo);
     mActionUndo->setIcon(QIcon::fromTheme("edit-undo", findIcon("edit-undo.png")));
 
     mActionRedo = mUndoStack->createRedoAction(this, tr("Redo"));//new QAction(tr("Redo"),this);
     mActionRedo->setEnabled(false);
     mActionRedo->setShortcut(QKeySequence::Redo);
+    this->addAction(mActionRedo);
     mActionRedo->setIcon(QIcon::fromTheme("edit-redo", findIcon("edit-redo.png")));
 
 //    mActionMinMap = new QAction(tr("Minimap"), this);


### PR DESCRIPTION
Fix #387 : 
- Ctrl + Q
- Ctrl + Z
- Ctrl + Shift + Z
- Ctrl + F
- F1

Check on Ubuntu 16.04.01 64bit
